### PR TITLE
Deploy under Python 3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/bionic64"
+    config.vm.box = "ubuntu/disco64"
 
     config.vm.provider "virtualbox" do |v|
         v.memory = 1024

--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -152,30 +152,30 @@ class compbox {
     }
 
     package { ['git',
-               'python-pip',
-               'python-setuptools',
-               'python-dev',
-               'python-requests']:
+               'python3-pip',
+               'python3-setuptools',
+               'python3-dev',
+               'python3-requests']:
         ensure => present
     } ->
     package { 'sr.comp.ranker':
         ensure   => $vcs_ensure,
-        provider => 'pip',
+        provider => 'pip3',
         source   => "git+${comp_source}/ranker.git"
     } ->
     package { 'sr.comp':
         ensure   => $vcs_ensure,
-        provider => 'pip',
+        provider => 'pip3',
         source   => "git+${comp_source}/srcomp.git"
     } ->
     package { 'sr.comp.http':
         ensure   => $vcs_ensure,
-        provider => 'pip',
+        provider => 'pip3',
         source   => "git+${comp_source}/srcomp-http.git"
     }
     package { 'sr.comp.cli':
         ensure   => $vcs_ensure,
-        provider => 'pip',
+        provider => 'pip3',
         source   => "git+${comp_source}/srcomp-cli.git",
         require  => Package['sr.comp']
     }
@@ -233,7 +233,7 @@ class compbox {
         require => Vcsrepo['/var/www/screens'],
     }
 
-    package { 'python-lxml':
+    package { 'python3-lxml':
         ensure => present
     }
 
@@ -300,8 +300,8 @@ class compbox {
     # API
     package { 'gunicorn':
         ensure   => present,
-        provider => 'pip',
-        require  => Package['python-pip']
+        provider => 'pip3',
+        require  => Package['python3-pip']
     }
     $compapi_logging_ini = '/var/www/srcomp-http-logging.ini'
     file { $compapi_logging_ini:

--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -143,6 +143,7 @@ class compbox {
                'python3-paramiko',
                'python3-pil',
                'python3-reportlab',
+               'python3-requests',
                'python3-ruamel.yaml',
                'python3-six']:
         ensure => present,
@@ -150,19 +151,13 @@ class compbox {
     }
 
     package { ['git',
+               'python3-pip',
                'python3-setuptools',
                'python3-dev',
                'python3-simplejson',
                'python3-sphinx',
                'python3-yaml']:
         ensure => present
-    } ->
-    # Raspbians's system pip is unreliable (specifically it experiences a
-    # TypeError if it needs to retry a download).
-    exec { 'install pip':
-        # `--upgrade` to encourage easy_install to get a fresh copy from PyPI.
-        command => '/usr/bin/easy_install3 --upgrade pip',
-        creates => '/usr/local/bin/pip3',
     } ->
     package { 'sr.comp.ranker':
         ensure   => $vcs_ensure,
@@ -183,7 +178,7 @@ class compbox {
         ensure   => $vcs_ensure,
         provider => 'pip3',
         source   => "git+${comp_source}/srcomp-cli.git",
-        require  => [Package['sr.comp'], Exec['install pip']],
+        require  => Package['sr.comp']
     }
 
     # Yaml loading acceleration
@@ -307,7 +302,7 @@ class compbox {
     package { 'gunicorn':
         ensure   => present,
         provider => 'pip3',
-        require  => Exec['install pip'],
+        require  => Package['python3-pip']
     }
     $compapi_logging_ini = '/var/www/srcomp-http-logging.ini'
     file { $compapi_logging_ini:

--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -143,7 +143,6 @@ class compbox {
                'python3-paramiko',
                'python3-pil',
                'python3-reportlab',
-               'python3-requests',
                'python3-ruamel.yaml',
                'python3-six']:
         ensure => present,
@@ -151,13 +150,19 @@ class compbox {
     }
 
     package { ['git',
-               'python3-pip',
                'python3-setuptools',
                'python3-dev',
                'python3-simplejson',
                'python3-sphinx',
                'python3-yaml']:
         ensure => present
+    } ->
+    # Raspbians's system pip is unreliable (specifically it experiences a
+    # TypeError if it needs to retry a download).
+    exec { 'install pip':
+        # `--upgrade` to encourage easy_install to get a fresh copy from PyPI.
+        command => '/usr/bin/easy_install3 --upgrade pip',
+        creates => '/usr/local/bin/pip3',
     } ->
     package { 'sr.comp.ranker':
         ensure   => $vcs_ensure,
@@ -178,7 +183,7 @@ class compbox {
         ensure   => $vcs_ensure,
         provider => 'pip3',
         source   => "git+${comp_source}/srcomp-cli.git",
-        require  => Package['sr.comp']
+        require  => [Package['sr.comp'], Exec['install pip']],
     }
 
     # Yaml loading acceleration
@@ -302,7 +307,7 @@ class compbox {
     package { 'gunicorn':
         ensure   => present,
         provider => 'pip3',
-        require  => Package['python3-pip']
+        require  => Exec['install pip'],
     }
     $compapi_logging_ini = '/var/www/srcomp-http-logging.ini'
     file { $compapi_logging_ini:

--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -155,6 +155,7 @@ class compbox {
                'python3-pip',
                'python3-setuptools',
                'python3-dev',
+               'python3-sphinx',
                'python3-requests']:
         ensure => present
     } ->

--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -151,12 +151,24 @@ class compbox {
         require   => User['srcomp'],
     }
 
+    package { ['python3-mido',
+               'python3-paramiko',
+               'python3-pil',
+               'python3-reportlab',
+               'python3-requests',
+               'python3-ruamel.yaml',
+               'python3-six']:
+        ensure => present,
+        before => Package['sr.comp.cli'],
+    }
+
     package { ['git',
                'python3-pip',
                'python3-setuptools',
                'python3-dev',
+               'python3-simplejson',
                'python3-sphinx',
-               'python3-requests']:
+               'python3-yaml']:
         ensure => present
     } ->
     package { 'sr.comp.ranker':

--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -113,23 +113,11 @@ class compbox {
         require => [User['srcomp'],File[$srcomp_ssh_dir]],
     }
 
-    # A local srcomp-http checkout so we can use the update script.
-    # It should probably get installed as a CLI endpoint at some point.
-    $http_dir = "${srcomp_home_dir}/srcomp-http"
-    vcsrepo { $http_dir:
-        ensure   => present,
-        provider => git,
-        source   => "${comp_source}/srcomp-http.git",
-        user     => 'srcomp',
-        require  => User['srcomp'],
-    }
-
     # The location of the live compstate.
     $compstate_dir = $compstate_path
 
-    # The location of the 'virtualenv' in which the the srcomp things
-    # are installed. Not really a virtualenv on this machine of course.
-    $venv_dir = '/usr'
+    # Path to the Python to use for controlling updates to the HTTP API.
+    $python_path = '/usr/bin/python3'
 
     # Update script, configured for direct use (via the above two variables)
     file { "${srcomp_home_dir}/update":
@@ -138,9 +126,9 @@ class compbox {
         group   => 'users',
         # Only this user can run it
         mode    => '0744',
-        # Uses $compstate_dir, $http_dir, $venv_dir
+        # Uses $compstate_dir, $python_path
         content => template('compbox/srcomp-update.erb'),
-        require => [Vcsrepo[$http_dir],User['srcomp']],
+        require => User['srcomp'],
     }
 
     vcsrepo { $ref_compstate:

--- a/modules/compbox/templates/srcomp-update.erb
+++ b/modules/compbox/templates/srcomp-update.erb
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 COMPSTATE="<%= @compstate_dir %>"
-VENV_DIR="<%= @venv_dir %>"
-HTTP_DIR="<%= @http_dir %>"
+PYTHON_PATH="<%= @python_path %>"
 
 echo About to update $COMPSTATE
 
-exec $VENV_DIR/bin/python $HTTP_DIR/update $COMPSTATE "$@"
+exec $PYTHON_PATH -m sr.comp.http.update $COMPSTATE "$@"


### PR DESCRIPTION
This changes compbox deployment to run under Python 3.

TODO:
- [x] Validate a `deploy` run which targets a Python 3 deployment
  - [x] Ensure the srcomp-http update script runs under Python 3 (~blocked on https://github.com/PeterJCLaw/srcomp-http/issues/4~)
- [x] Validate build under Vagrant (including validating a `deploy` run)