### PR TITLE
Make systemd restart services if they crash

### DIFF
--- a/modules/compbox/templates/service.erb
+++ b/modules/compbox/templates/service.erb
@@ -6,6 +6,8 @@ After=<%= @depends_str %>
 User=<%= @user %>
 
 Type=simple
+Restart=on-failure
+MemoryLimit=150M
 
 <% if @start_dir %>
 WorkingDirectory=<%= @start_dir %>


### PR DESCRIPTION
While this doesn't actually fix the memory leak in srcomp-stream, this will at least mean that when the OOM kill it, it returns.