### PR TITLE
Ensure that nginx is reloaded after certificate renewals

### DIFF
--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -481,6 +481,10 @@ class compbox (
                 '/etc/nginx/sites-enabled/compbox',
             ],
             notify  => Service['nginx'],
+            post_hook_commands  => [
+                'echo "reloading nginx after certificate renewal"',
+                'systemctl reload nginx',
+            ],
         }
     }
 


### PR DESCRIPTION
It appears that this wasn't always happening. Quite how that happens given that nginx is involved in the renewal is not understood, though it seems that it wasn't happening.

In any case adding this reload should be safe.

Have applied this on a public compbox instance and inspected the hook file. That contains the expected command.
Not really sure how to test this beyond that.