### PR TITLE
Move to a verison of the pystream which pins setuptools-scm

### DIFF
--- a/modules/compbox/manifests/init.pp
+++ b/modules/compbox/manifests/init.pp
@@ -358,7 +358,7 @@ class compbox (
     package { 'srcomp_pystream':
         ensure   => $vcs_ensure,
         provider => 'pip3',
-        source   => 'git+https://github.com/WillB97/srcomp-pystream.git'
+        source   => 'git+https://github.com/PeterJCLaw/srcomp-pystream.git@pin-older-setuptools-scm-for-compatibility'
     }
     file { '/var/www/pystream':
         ensure => directory,


### PR DESCRIPTION
Currently deployments of this package into the compbox do so into the global Python space, which uses the system-installed setuptools which is older than the latest version of setuptools-scm supports. Move to a version of pystream which pins an older version of setuptools-scm so that such installs continue to work for the time being.

See also https://github.com/WillB97/srcomp-pystream/pull/12

On testing this resolves this issue we were seeing running puppet.